### PR TITLE
Populate Activity objects returned by list_activities and list_friends_activities

### DIFF
--- a/lib/WebService/Strava.pm
+++ b/lib/WebService/Strava.pm
@@ -361,7 +361,7 @@ assistance and a lot of boiler plate for this library.
 =head1 BUGS/Feature Requests
 
 Please submit any bugs, feature requests to
-L<https://github.com/techamn83/WebService-Strava3/issues> .
+L<https://github.com/techman83/WebService-Strava3/issues> .
 
 Contributions are more than welcome! I am aware that Dist::Zilla comes with quite a dependency chain, so feel free to submit pull request with code + explanation of what you are trying to achieve and I will test and likely implement them.
 

--- a/lib/WebService/Strava.pm
+++ b/lib/WebService/Strava.pm
@@ -204,8 +204,10 @@ method list_activities(:$activities = 25, :$page = 1, :$before?, :$after?) {
   $url .= "&after=$after" if $after;
   my $data = $self->auth->get_api("$url");
   my $index = 0;
-  foreach my $activity (@{$data}) {
-    @{$data}[$index] = WebService::Strava::Athlete::Activity->new(id => $activity->{id}, auth => $self->auth, _build => 0);
+  foreach my $activity_data (@{$data}) {
+    my $activity = WebService::Strava::Athlete::Activity->new(id => $activity_data->{id}, auth => $self->auth, _build => 0);
+    $activity->_init_from_api($activity_data);
+    @{$data}[$index] = $activity;
     $index++;
   }
   return $data;
@@ -227,8 +229,10 @@ method list_friends_activities(:$activities = 25, :$page = 1) {
   # TODO: Handle pagination better use #4's solution when found.
   my $data = $self->auth->get_api("/activities/following?per_page=$activities&page=$page");
   my $index = 0;
-  foreach my $activity (@{$data}) {
-    @{$data}[$index] = WebService::Strava::Athlete::Activity->new(id => $activity->{id}, auth => $self->auth, _build => 0);
+  foreach my $activity_data (@{$data}) {
+    my $activity = WebService::Strava::Athlete::Activity->new(id => $activity_data->{id}, auth => $self->auth, _build => 0);
+    $activity->_init_from_api($activity_data);
+    @{$data}[$index] = $activity;
     $index++;
   }
   return $data;

--- a/lib/WebService/Strava/Athlete/Activity.pm
+++ b/lib/WebService/Strava/Athlete/Activity.pm
@@ -125,7 +125,11 @@ sub BUILD {
 
 method _build_activity() {
   my $activity = $self->auth->get_api("/activities/$self->{id}");
- 
+  $self->_init_from_api($activity);
+  return;
+}
+
+method _init_from_api($activity) {
   foreach my $key (keys %{ $activity }) {
     given ( $key ) {
       when      ("athlete")           { $self->_instantiate("Athlete", $key, $activity->{$key}); }

--- a/t/WebService/Strava.t
+++ b/t/WebService/Strava.t
@@ -55,6 +55,8 @@ sub strava_test {
       if (@{$activities}[0])  {
         is( ref( $activities ), 'ARRAY', 'Activities is an array' );
         isa_ok( @{$activities}[0], 'WebService::Strava::Athlete::Activity');
+        #Check data was populated
+        ok( defined( @{$activities}[0]->start_date ));
       } else {
         note('Current authenticated user has not got any activities');
       }
@@ -63,6 +65,8 @@ sub strava_test {
       if (@{$friends_activities}[0])  {
         is( ref( $friends_activities ), 'ARRAY', 'Friends activities is an array' );
         isa_ok( @{$friends_activities}[0], 'WebService::Strava::Athlete::Activity');
+        #Check data was populated
+        ok( defined( @{$friends_activities}[0]->start_date ));
       } else {
         note('Current authenticated user has not got any friends with activities');
       }


### PR DESCRIPTION
Populate each `WebService::Strava::Athlete::Activity` object automatically when `list_activities` or `list_friends_activities` is called using the data already retrieved from the web service.

I also fixed a typo in the github URL in the POD of Strava.pm.